### PR TITLE
Conform to shellcheck, support custom branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # problem
 
-```
+```sh
 ➜ git branch | wc -l
       325
 ```
@@ -9,3 +9,11 @@
 
 ![trash](/trash.png?raw=true "trash")
 
+By default the current branch along with the branches `master`, `develop` and
+`development` will be ignored. The current branch and `master` can never be
+trashed but you can customize other or additional branches to ignore by setting
+`SKIP_BRANCHES`.
+
+```sh
+➜ SKIP_BRANCHES="branch-1|feature/v3" git-trash
+```

--- a/git-trash
+++ b/git-trash
@@ -1,10 +1,12 @@
 #!/bin/bash
-currentBranch=$(git rev-parse --abbrev-ref HEAD)
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+SKIP_BRANCHES="master|${current_branch}|${SKIP_BRANCHES:-"develop|development"}"
+
 branches=()
 while IFS='' read -r line
 do
     branches+=("$line")
-done < <(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -E "master|develop|development")
+done < <(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -E "$SKIP_BRANCHES")
 
 trash=()
 
@@ -25,6 +27,10 @@ for branch in "${branches[@]}"; do
     echo
 done
 
+if [ "${#trash[@]}" -lt "1" ]; then
+    echo -e "\nnothing to delete"
+    exit
+fi
 
 echo -e "\nyou will delete the following local branches:"
 printf '%s\n' "${trash[@]}"
@@ -39,4 +45,3 @@ if [[ "$ans" == "trash" ]]; then
 else
   echo 'coward'
 fi
-

--- a/git-trash
+++ b/git-trash
@@ -1,21 +1,26 @@
 #!/bin/bash
 currentBranch=$(git rev-parse --abbrev-ref HEAD)
-branches=($(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -E "master|develop|development|$currentBranch"))
+branches=()
+while IFS='' read -r line
+do
+    branches+=("$line")
+done < <(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -E "master|develop|development")
+
 trash=()
 
 handle_choice () {
     echo -n "$branch [y/n/?]: "
-    read -n 1 ans
+    read -r -n 1 ans
     if [[ "$ans" == "y" ]]; then
-        trash+=($branch)
+        trash+=("$branch")
     fi
     if [[ "$ans" == "?" ]]; then
-        git branch -vv --list $branch
+        git branch -vv --list "$branch"
         handle_choice
     fi
 }
 
-for branch in ${branches[@]}; do
+for branch in "${branches[@]}"; do
     handle_choice
     echo
 done
@@ -24,11 +29,11 @@ done
 echo -e "\nyou will delete the following local branches:"
 printf '%s\n' "${trash[@]}"
 echo; echo -n "type 'trash' to do it: "
-read ans
+read -r ans
 
 if [[ "$ans" == "trash" ]]; then
-  for trashbranch in ${trash[@]}; do
-    git branch -D $trashbranch
+  for trashbranch in "${trash[@]}"; do
+    git branch -D "$trashbranch"
   done
   echo 'done'
 else


### PR DESCRIPTION
Address [SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207), [SC2162](https://github.com/koalaman/shellcheck/wiki/SC2162), [SC2068](https://github.com/koalaman/shellcheck/wiki/SC2068) and [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086).

To make this useful for me I added the `SKIP_BRANCHES` variable since we use names like `dev`, `stage`, `prod` etc.

I also took the opportunity to exit the program if there's no branches to delete.