### PR TITLE
Add -x flag to match exact lines

### DIFF
--- a/git-trash
+++ b/git-trash
@@ -6,7 +6,7 @@ branches=()
 while IFS='' read -r line
 do
     branches+=("$line")
-done < <(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -E "$SKIP_BRANCHES")
+done < <(git --no-pager branch --no-color --format='%(refname:short)' | grep -v -x -E "$SKIP_BRANCHES")
 
 trash=()
 


### PR DESCRIPTION
Previously if there were multiple branches with the same leading characters then the diffing trailing characters would be excluded. I have been working on a `feature/tv` branch for a while and have had my `feature/tvDetailPage` branches excluded and I feel awful about it.