### PR TITLE
Add main to SKIP_BRANCHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Delete your old branches that you always forget to remove when you're done!
 
 ![trash](/trash.png?raw=true "trash")
 
-By default the current branch along with the branches `master`, `develop` and
-`development` will be ignored. The current branch and `master` can never be
+By default the current branch along with the branches `master`, `main`, `develop` and
+`development` will be ignored. The current branch, `master` and `main` can never be
 trashed but you can customize other or additional branches to ignore by setting
 `SKIP_BRANCHES`.
 

--- a/git-trash
+++ b/git-trash
@@ -1,6 +1,6 @@
 #!/bin/bash
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
-SKIP_BRANCHES="master|${current_branch}|${SKIP_BRANCHES:-"develop|development"}"
+SKIP_BRANCHES="master|main|${current_branch}|${SKIP_BRANCHES:-"develop|development"}"
 
 branches=()
 while IFS='' read -r line


### PR DESCRIPTION
Esteemed members of the project council,

On GitHub (popular code website) the branch formerly known as `master` (word with bad connotations) is now named `main` [by default](https://github.com/github/renaming).

I hereby propose that a branch with the name `main` should be treated as an equal to one with the name `master` with regards to wether or not it shall be skipped. In other words it should always be skipped regardless of the user provided branches should the `SKIP_BRANCHES` environmental variable be overwritten. For all intents and purposes, `main` and `master` are interchangeable.

Furthermore, I propose adding two milestones to the project to be reached _when most appropriate_:

i) A branch known as `master` should be added to the second tier of skippable branches, i.e. the mutable default where `develop` and `development` now reside.

ii) A branch known as `master` should be removed from the skippable branches completely unless explicitly added by the user in the `SKIP_BRANCHES` environmental variable.

Thank you for considering my contribution.