### PR TITLE
Fix regex for excluding branches

### DIFF
--- a/git-trash
+++ b/git-trash
@@ -20,7 +20,7 @@ do
     fi
 
     branches+=("$branch:$status")
-done < <(git --no-pager branch --no-color --format='%(refname:short):%(upstream:track)' | grep -v -E "^$SKIP_BRANCHES:")
+done < <(git --no-pager branch --no-color --format='%(refname:short):%(upstream:track)' | grep -v -E "^($SKIP_BRANCHES):")
 
 handle_choice () {
     IFS=: read -r branch_name tracking_status <<< "$branch"


### PR DESCRIPTION
With the formatting of `%(refname:short):%(upstream:track)` the output will print all branches followed by a `:` and the tracking branch. To properly ignore all `SKIP_BRANCHES` we want to add the `:` after any matching value in the group and not just the last one.

This fixes a bug where the current regex is too greedy and matches the beginning part only of all branches except the one specified last.